### PR TITLE
Itrc results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.tif filter=lfs diff=lfs merge=lfs -text
+*.img filter=lfs diff=lfs merge=lfs -text
+*.rrd filter=lfs diff=lfs merge=lfs -text
+*.img.* filter=lfs diff=lfs merge=lfs -text

--- a/results/wy2015/README.md
+++ b/results/wy2015/README.md
@@ -2,30 +2,4 @@
 
 This directory is meant to supply and overall average _ET_ for the complete Water Year 2015 (2014-10-01 thru 2015-09-30).  
 
-# Rasters
 
-You may supply ```ET.tif``` showing the average daily _ET_ for the Delta Service area for the entire year.  
-
-# CSV files
-
-You must supply a table of the monthly ET (```monthly.csv```) over a set of regions for the Delta Service Area.  The regions must include: dsa,islands,points,crops?
-
-
-## CSV formats
-
-For the ```monthly.csv``` file, the format is shown below.  The date is the first date of the month for which the estimate is made.  
-
-```
-date,region,ET,(ETo,Kc,....)
-2014-10-01,dsa,5.1,...
-2014-11-01,dsa,4.3,....
-```
-
-
-The ```daily.csv``` follows the same format, with the date showing the actual date for the estimates.
-
-```
-date,region,ET,(ETo,Kc,....)
-2014-10-01,dsa,5.40
-2014-10-02,dsa,5.43
-```

--- a/results/wy2015/dates/2014285/README.md
+++ b/results/wy2015/dates/2014285/README.md
@@ -1,3 +1,0 @@
-# Instantaneous Hi-Resolution data products
-
-Here is where you locate your instantaneous data products. For example, if you are using landsat imagery to determine instantaneous _ET_ for a particular overpass, this is where you store those data.  We expect most of the data here to be GeoTIFF files, and had the naming parameters as described in the [results README](../../../README.md).

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66332b265bcf0c817e8b0daf97ecaaeabf74922b5a100c278b1ce5479ebf5cbe
+size 31144689

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7452cbce0b9e52cbd10ad66e1a4262d06f426409955316c901ad448cf2d4f13e
+size 2242

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c84bc9c150fc73027f9b75790c8cf9627fc5cb35c14fa22bf9b522e8da077e5
+size 6151

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.rrd
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0f86253d73d592b64f4b84bf6bdcafae5d8f3d25891d14dbfd131d727841492
+size 12354480

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:854986ad970d453813b18c1256cfab5dae6dbe553b36fdea5b21cb1edd3d8a1f
+size 31144672

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9cd67e8bdb463d1c5cd9ce9f9c5f52a1d48325adcdeffe93f03b356087b2bc
+size 912

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8bf612b00f81b5de93b83fa42c4221fbb001c72e8a6b21ecbf6e3eb58278bb4
+size 6160

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.rrd
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b56123b7ff29f091edef75ab0d31d7d216582499aaea0946b609f8ddfb9445c
+size 12354477

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0964893de91b670c0e4914f710d9c66116c2f4cd03525f5c18b8452018bb07f1
+size 31144670

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img.aux.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984a3945c2cd4e36d36cc6071d8d6d090dae97f2ce9105243536caff623fa286
+size 685

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee1a21691cee99d0c797ae8e08493f79943a861132b7e756463ca1a77afdec56
+size 6136

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.rrd
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12c6626b0b7803bae13b79086d4671e4de5f89f1ca56909e8a1aa37e67ec28bd
+size 12354474

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53883f56d60dbfec25c8a08f45a643b993fd31e64f5b505c4ccf7cf5a68e0b69
+size 31144670

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0445af5556061500e20eb51fb2d2f526db3d9fa0c55ae34fa6fd068abe6da3ec
+size 684

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img.xml
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd055ac392c6082ea371ddb0797a879029898b1d1aee5cd75fa3e34f2e53b18
+size 6143

--- a/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.rrd
+++ b/results/wy2015/dates/2015_144/ITRC_Delta_2015_May_24_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b649abde9682309c669d4df647abb1a80b74a5f29368b765ae251fef406997c1
+size 12354475

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a181bf5e35d9a3b775c00268a00cdb2b96b521400a53e4e0c34ba2139b18d13a
+size 31144689

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d7235cc515e147232d33c968f806a1b8cd2a3ac23354bb89ee781daecd2b507
+size 2263

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab7ed4520dc0f671121a9da8cce6a66ba130a428adb22fcc997dd43e4aa959ba
+size 6151

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.rrd
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bf5039beed589f509fcb8e843012688ccb690a08759d7e424031e9fc71dafdf
+size 12354480

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3ecc022266308a56e3820ee5d0cbd365e500696c7078c323e50e79a75ada0e
+size 31144670

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img.aux.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2039816b365875aec2cf2acb51853a6dd25c34d231362a3ec04ce385c79f065a
+size 685

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6cae476b5e57a3d67d44cfe939ea40c455178d99058602c334f1b37797f2597
+size 6139

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.rrd
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_Jun_25_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9752c5b878769633b7f0266299bff59d82ac521519906948ecf92550864a711
+size 12354474

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e5dc772e9cc23061f48310c7208bc52981fc7eb22f0e28a13c0f0db28cd058b
+size 31144670

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb788163017be86e370c80facec46f6f345e780b5fd934afa57dd6742dfabe1
+size 684

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75e945bd727d6b0ecd4e058b9299e1c26c88a1718212ff80382d5923d7caa0b6
+size 6137

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.rrd
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75376c421887a3bbc919ba6b08f02d075a4d1002620522a6827a2351307765af
+size 12354478

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d03f306d93246ee9d2e802c91e65e663626ea5983a22f3eafda0ca7b7fde57f
+size 31144670

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:945288dd045d8550ad90bc770e9697c0975f24e110a6fef20e42eb4431981d0d
+size 684

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img.xml
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5fd71ffc577ff3baa1dedbea1620a10026aa85e11a813673cfd49fbe1a43c30
+size 6150

--- a/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.rrd
+++ b/results/wy2015/dates/2015_176/ITRC_Delta_2015_June_25_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cde347c505f1290322610180b108959d1c2d7b4c4fb3454d94925539b2157c80
+size 12354476

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce2d086dd41a86a38ccb6059131bc6e6503ad9f5862ba6c8c49de5313438c3a5
+size 31144689

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08fda20f11a7a98fa60a4791f3d867c93ed2d7565b48cda48c5dd2370f6fc8cc
+size 2246

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb27f6e072e80f541d852fba0afc6af87e440e61f458e3bf5e0c13bf13db1a8
+size 6151

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.rrd
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a15f52ad3e2ea11796890e863dc73759b044b2cc11e0f033e9a128aba6a82de0
+size 12354480

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92b8c58d1e96a2d9bbe28ad287584173463c69a66182f36b23874ee0b6469edc
+size 31144670

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7c5725ec79060f5061f03934567cbbbfd9052f8d34cc21e80be3ca621caa960
+size 684

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab47c9bcd65a1b9feed44aad5b289df8101480e758e1b48c1d392ad0f1ab2eb5
+size 6133

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.rrd
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36e328f3c1bbad2fee8b6a985bfae09efbfcd9c4fc115b4a7765f7082f57919e
+size 12354477

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:160015b22adc7dad56d38081c5242cf3dbf36e65db39ea289c6cc1cdae511480
+size 31144670

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img.aux.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f334ab9cf92d031611c07c956d9d1efa8a14494e80cd2c486164da7225b23aa
+size 684

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f749cbdde52b4996cfad61c2252ea588a74f937876929af860c7b7f99d05b43c
+size 6136

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.rrd
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_Jul_11_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fe151bc8b21aa8c736ff60acb6a8e8251dfe861bbde5cd8fdaa694d38f03a6c
+size 12354474

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:579475f85b428f611c94ae50626dfc4c957548b18ac232afeb565578b00f3340
+size 31144670

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ae17c8f1be575ad2863a4ae572a9f88b53a7ff3b8e485f34ca058c73b09c953
+size 684

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img.xml
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e5f171e7ac15a03e663fad80b25ee5ef746bcbf2ab4acd94863ecaaf3391da
+size 6147

--- a/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.rrd
+++ b/results/wy2015/dates/2015_192/ITRC_Delta_2015_July_11_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d512d99b0ce8f01ee6f0ff8a55c4325447951276ce103adfcca6cf649fd38f3
+size 12354476

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e3320556ad530322413684afcf65de534585a05cb501162058cc4d8aa4602d1
+size 31144689

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:267c47e7a1e866c458a233092f53fbd18f2267b2da6b72542f7d30a029b53254
+size 2128

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0724f4c92d12d6d2c57c006a5c6e03545b77df6dfdaa6660ba77f09d96d2b3c9
+size 6151

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.rrd
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46630a6a61775b35ba517327fc42f1acc3413b3dd65e38212e7e123fa9a9bd24
+size 12354480

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670781fcaf6ef0b0bbe918e9585c7cde603923a78be261ea376417d2b9379869
+size 31144670

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96baee5feed35f989ed2da82177e1a0a90b03b35fd8b2dac16f200266bd63ab3
+size 684

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39b9c5b4f9b4177cf8a4ba4f492414273b7ba772c83fc692b385b3baf6b97335
+size 6133

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.rrd
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af9624eae067fed209ebca5febc0b7258a92f5ccf83e544c7daef3ab0d2a1350
+size 12354477

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f04284daee34abe398d709bda3448e677af482b9bf3d842057dbdc30ca15d86
+size 31144670

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img.aux.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77d8ee9f06f7747778892a9fa717e76dce895d5142229190698ddefb3c5a25fa
+size 684

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26521b32d8b7145842b72aca326449a94c676bab29a79ad3b2385af1199fc47d
+size 6136

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.rrd
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_Jul_27_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db62c3ed04dad63e4a07ae3329cf95f3f713d4fd46f2038cf4fa37b8de9127e3
+size 12354474

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e4dffee124ddcf15af5eb3dfcd0d8f460771406d0d85fbce3289710122f280
+size 31144665

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b63da01713820f90fd3582ae2750313a2c50216c1e9f1e9f7253cbc2f1e62bed
+size 684

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img.xml
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b27e3a699444ea161dcbdf4bc80c1b913a22401d85bf27a10f9938942aad4b61
+size 6147

--- a/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.rrd
+++ b/results/wy2015/dates/2015_208/ITRC_Delta_2015_July_27_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895ed425406754e6918c53df4f0741c266f46452ef932fbe9607cf4f53fb3483
+size 12354476

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6641a651a6fdae474d75b77da17eb25a2426c4b74c0b874ae5f42117f75d428d
+size 31144689

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d50a356749c9b9b4c6c4a9b6decf0270c48c6c43f3d5ce6c942831e28098458
+size 2139

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50624be3e5b9f8dd095fe6b8d28994de303eeda9e5d184c83979f1106394de6c
+size 6151

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.rrd
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0f35d360d5ef28167ef33077b5aa71e411831b1d233d641563a68b55e8e713
+size 12354480

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd1f10d86e9a9cd4d8fe0a2a074e3d01441fd28adbe6d753c4999e3ed1dd3df0
+size 31144665

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac0028b13086ce8eadcb8ed70fe52a6d48dfceda87bb368d66c139836b78dbc1
+size 684

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70044b934ad513fd47fefd1c56cee901cdff26c596ae4b00aa498f13ac8b1e3
+size 6133

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.rrd
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a77e668dce0bf5e63a75e10a76d6286c64f5fb4156f9520f0609e90cd74dc6a5
+size 12354477

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2d752cc7dd79b52aae3ac09bdeebdc86bb71ebd2f71dc69e2304d18ac762a60
+size 31144660

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img.aux.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e359ae468ecb110981bf6acf82157085dce0619db632e41a6c2fa5d1aa94fb4
+size 685

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d28f28f4392d4d09e5bcd5755b382c61f3c0fe1c887f8886f78fdf628394278f
+size 6136

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.rrd
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f54d1c2a6375802c2c98e690b8e484450a7f8c40544a9669637a7ba71ae4fa9
+size 12354474

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b34207fdfd775d0c36b2f3207fb56442a9309b3e3110fe0b49265575c27661e5
+size 31144670

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dde9a909f8260948445b4508ea7bcbf21313a69d7341406dcc2474e78e1bfe2f
+size 684

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img.xml
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e470b8ab24c3a8c31cea72ac8a1b005da3eee4fbe449b3f325254382f6d2a8c8
+size 6143

--- a/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.rrd
+++ b/results/wy2015/dates/2015_224/ITRC_Delta_2015_Aug_12_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a27fb24c9c2e14ae7b33d1c7579a852340682de15763f692ce71585fc58a77e
+size 12354475

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d0554f9429fef7a8ba847493a7822cd4a462a132edd6c3a3097ac6330ca0557
+size 31042582

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img.aux.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:403c3e245506ab5405f76351a5f8464f0a75abeb9b9c079c12e0baadc9fcd8ef
+size 2362

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c738e57a538618f72d588f11c917bb93341f19bc56fc2dc28852576095447098
+size 6159

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.rrd
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a682c52d2337a70820454b6080dd633933b670b831b41bb050e98fd8607dc510
+size 12354481

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:343c8b49faaf6ef2da728773cb25945d36024a1fd68ec49be9ed5d419bfe9e62
+size 31140830

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img.aux.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0efe3646fdc19283b0c2035277d0d887cb36f678519d41d8f1a840827a240572
+size 683

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:465541a27c94c7b0e20d5041f6b66052767bdcd294b1b5f02ebd20660154b4db
+size 6140

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.rrd
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831a868083d18970acee43b24e7e5e23358ad5f980c07a5b81712b7c76e9790e
+size 12354478

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b44164ffec5002aa3687b5998353b6412c0e2edc8891f392f0c8d49f10ff9d93
+size 31035774

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img.aux.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5479f4189e0c0a4b6f9229f891043d233f5b2135db54a5b5684460a15c9f441f
+size 684

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12273c90aeb8bf539e8564c79ded88f22341480258494eb9098973db4ab7702c
+size 6144

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.rrd
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f70cbd61a5c17598c769d8bef2489c626346272029e348764147bec0e36199c
+size 12354475

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:308355f5fd409a2d76e987e713c901d0837f5a870258dc762852683f98dd69f7
+size 31142890

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img.aux.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78339698cc550e1425bf8b522ff4458063e2e7541583ffce445fdc61a7903a88
+size 669

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img.xml
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfce1b1b844476f23417f41e01a69ac2e14f8d028c3f5697c1ddb90b9e4f39f7
+size 6151

--- a/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.rrd
+++ b/results/wy2015/dates/2015_264/ITRC_Delta_2015_Sept_21_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7525d2958011ef01eead226e2c6cb02b1d911714b4c074515ac5e7215a8556f6
+size 12354476

--- a/results/wy2015/monthly/ITRC_Delta_WY2015_Kc_co.tif
+++ b/results/wy2015/monthly/ITRC_Delta_WY2015_Kc_co.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9158d53ef41cc0a985e91d7c6753be294192350df89f629852ba503c8b91ff77
+size 325312646

--- a/results/wy2015/monthly/ITRC_Delta_WY2015_Kc_or.tif
+++ b/results/wy2015/monthly/ITRC_Delta_WY2015_Kc_or.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7e639aaebfff4752fcefe3b63f0101309aafb21cb9d99832462c60d0d290417
+size 325207935

--- a/results/wy2015/monthly/ITRC_Delta_WY2015_dailyAvg_ET_co.tif
+++ b/results/wy2015/monthly/ITRC_Delta_WY2015_dailyAvg_ET_co.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e244f793fda935bf9147e7828a4eb6d61c8ba7bfc03617857e4b2948e983c46
+size 328761373

--- a/results/wy2015/monthly/ITRC_Delta_WY2015_dailyAvg_ET_or.tif
+++ b/results/wy2015/monthly/ITRC_Delta_WY2015_dailyAvg_ET_or.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e1423ca62ebf5e485f97969e9f8a8b03448d4636ebf559a2073d52590fa62a
+size 328811089

--- a/results/wy2016/README.md
+++ b/results/wy2016/README.md
@@ -1,0 +1,5 @@
+# Water Year 2016
+
+This directory is meant to supply and overall average _ET_ for the complete Water Year 2016 (2015-10-01 thru 2016-09-30).  
+
+

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21f44b83eeb2de7e58430d6dc59d3022513020d6ded694a0a39f29e61208e09e
+size 31148299

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc4202180d29ab97bcf18f3dd22d7635e95be6b6864428e1d17d3cc2fd18d4de
+size 1666

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d82718334ba18bf150cabc6198178d321f64caefafddb46f37382f1d5c5f89a
+size 6151

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.rrd
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bdc33ba4b733ef77e5d8d250e90d04d5cd665f325ea5c207481c5585fc3a107
+size 12354480

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93a07ca371091a78f114829ca3fd1094ccff14bf5abdf350f14f0c34bdd009b1
+size 31148280

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fb9de093569479ddbe25cad494bf59f2163cfa740f78d448672e510f3ac6424
+size 683

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:602694d554ecebc19c6df958627d187402b816233ae6a1229ca0326884f565f2
+size 6133

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.rrd
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee21d6d79e6d0f5faa33c661e86a7affeed5ac8164041b7b92fec301c8f6e1ea
+size 12354477

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2c62b546b46662b4bd8da378d11f8bd9f711702513519e0f2e696566d8e9a6c
+size 31148280

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img.aux.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a9234f1366f396ad7bc1f79e1afa547f10182f1d4b1978f8a3d7680eedf676
+size 685

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4218ac6ded4b62ede89e233139d9ed6406d454369ff1fd43f69f26447f6fb123
+size 6136

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.rrd
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96828ce7b4ceb3b1122377ca973f967ba2549adc21916a844446789184496c5e
+size 12354474

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c2e1771ce7e2a5cd63b3324ea3e99db645b0dddcfffb66561d8f239beb2511c
+size 31148275

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:441631f7781e173e447a09865321a5334e068a8ccc48b124379899e3d15cfcf3
+size 684

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img.xml
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:467b3ee81376725ea32d6de57dd424d2fd2f25229038015e6a540835d5642916
+size 6143

--- a/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.rrd
+++ b/results/wy2016/dates/2016_131/ITRC_Delta_2016_May_10_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed33dd09822901b6ac7ee54ccd12ba52e9f4737dfbdb3b9cb528332fc0a11478
+size 12354475

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adaf635dffb1c4892175676e0f6cd44c5a75cb56d26edde45c77401e85a21f89
+size 31148299

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a74f70aafee29a5281be981eec926cf31899572ec101a577f2c9c080e271042f
+size 1654

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978cac26831858749858fb549c718973fb6e816b3b05d85026566bc23b9e415d
+size 6151

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.rrd
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:505e3b15d70f21a575bda39be017a1ced7ad5911087ca499e50d7736eee51652
+size 12354480

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43af87fe48221e17647b2e151f14e176d9d3c29ba7529952764e9c903bbd503e
+size 31148280

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25c6a6d6da3e8ca8daa09cc8acb421ba69370e4719b0fd9330ac43a4e509c81f
+size 684

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb116f214eca75051b07fd7e6d240e22d4d8d25b868103515f3f817c62aa81e
+size 6132

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.rrd
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b179e6c3a4dbf11883af9b6ae405aac6023ae10c23596a02b6fe19b5e0e1c11a
+size 12354477

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e674ece1ff176fe5cb5d3004f94222821e0df33b5512a9cf5ee858832ab82487
+size 31148280

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img.aux.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a74151728596fe617fb94e226ae473f5789381d93ccd11bc9c6f4cc74c857b5
+size 685

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b67739ce0cb4e98e365e0dfc6928e752236d5f67b67a650c9c7385501acc0c6f
+size 6136

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.rrd
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5097f9dd3b9526a5d6ae69bf10412a8ac08de0e85816fed6c5fd7045d533f1e8
+size 12354474

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba7df299d05dc530317e33c82205cc9838c54b96f52016775f5aa1b934116322
+size 31148275

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8facc6d0a08dd8ce1bd1df70cb6d6c40e334c71359d212d81733bbb27816c09
+size 684

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img.xml
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d835ed59bd385d89b7633c3cac7b602d6324a2770f5840b9dbe92a78c23dd3a1
+size 6143

--- a/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.rrd
+++ b/results/wy2016/dates/2016_147/ITRC_Delta_2016_May_26_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e53abe60da4951b034a230ea473dad9950f8629c804c692f00787b70f4c059f
+size 12354475

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7f00c1e308a68da196479ddc41198115e5685a914f9ef967700f026016516c9
+size 31148299

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f42ca0573f4664c0ac832df213089fe4e9a8d690a3b1ac52c631003b72a2d9c2
+size 1689

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6e271e9c42faabaafb6caaceff6bab9dafb9014a80e0f5cae50ab0edcb4124b
+size 6151

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.rrd
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d8b6f31499b62b35384f85556c164e2edda1c4f53b50916b49b27f8115948fb
+size 12354480

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70306b756c399511da9464de7cba6a25aba04baf797cafe2bccbd45903850bff
+size 31148275

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7e1a57d13af007ce754d0f6fd94a142212212c97bfbba3b89a94925bb9364e6
+size 684

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:944c1621938a3156864bf125761b22d40f7084d5b2402f82694057665c66607d
+size 6133

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.rrd
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae415e52abf1828a983521e2265b0c3417e7fab828311d064e8c6d594d1ef766
+size 12354477

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b01554ba46d3295553940d578178f5a9aa689d8b5e69b4f218916e1f4d8703c
+size 31148280

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img.aux.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa2a22b81314453705657392101a9321bb79346167c6a65b92c7dd100dd07cd4
+size 684

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06e8ccdeccdfe0f1083b11b0fa7ce519ad807f67db193221c4e5dc9752cef935
+size 6136

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.rrd
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e1d1e6ccf0e2e41b44b7b92c7e1fe03fadefe5b3aa6932d68ca9e466170401f
+size 12354474

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ced9314e98b66697375aeac1b102f5a7c6aa6db305adcea1a2d9517706b6a04
+size 31148275

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7952d6533aa0398a919194a411644c4b393283b1c4cea2af0e77bf5824cc4ebd
+size 684

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img.xml
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e00f73875a0d2629597aba9c7369bd3f04ef0acfbec88b1ffc67d463b1b96675
+size 6143

--- a/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.rrd
+++ b/results/wy2016/dates/2016_179/ITRC_Delta_2016_Jun_27_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c546e09ede4f6428ceef62ac415398a06b5f2750e9b3fde36f8367775865a177
+size 12354475

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d5e731c61a3b53e0246f881c819cc71f1bb5d23510be78c9b2356401f572d55
+size 31148294

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f12506bce9b251e592db7483beeac49398f942c783fde697488d1874cf3275a
+size 1686

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e58dcf96b5bf5bbdfcb2ce33580f1b0aab288989d0e6e3b9b69d5826bf7082c8
+size 6151

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.rrd
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d20f38bdd7ed60b4d58436833d012c1d54d265a655c8513a846da8cb5ee116f3
+size 12354480

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f180bda42627881c45d156813b659abcb733571f4d8e7bab739ad66a9486d2fd
+size 31148275

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb8b8866867a5f44196461a6cf36378b3cad9d24505550b47d3fe9815f1044b6
+size 684

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f38f9ca154e4debe5fc917d630fca306650eec782a5ea24839aa404d410b787c
+size 6133

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.rrd
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2306afd249107b0348d62b1bb905161c040434dd9d7f6df0b77b759428a834e
+size 12354477

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afbcb06f0e93bc237c095d12eec94b1db127625f3fe4793c6b227c9c313152cd
+size 31148280

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img.aux.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ddc900cf13adc3e4ab5e1ef371fd7adbd730e07c480a05751cc183e0b54513
+size 684

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:793cbf0eb389178f953e99b87dea2016f5cd4477b033423be6903500c4deaa45
+size 6136

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.rrd
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b2fa23130ec7c049320085d7d4d616bedcab5f40e1a0249d1aceed6893d2fb3
+size 12354474

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc4b43d63292586280659345c72f51ddfe85678302fe9e58c7286d90c974a6bb
+size 31148275

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f8b4a982fa11b489d952a634c99bfa7eb30363fd7a1e07b44ac2d022dc848a
+size 684

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img.xml
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75d56dd5cc083d972b8d6e013d24a9e1e66a48d3bbd1f57cc87ee394346707e0
+size 6143

--- a/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.rrd
+++ b/results/wy2016/dates/2016_195/ITRC_Delta_2016_Jul_13_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:298e91eea8a726d8b1d0897402bbb6de702f33ac15b9ad69de2a3fab7960af30
+size 12354475

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c4765890bfc5d711c93fcb41ea8a17a9f1e01fc0d0565c3ba9bda0fb8f0facf
+size 31148299

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fedbb24dcbb66df2fb3303199d8f586a788eada0411325be989a93e840486a73
+size 1665

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a3537a373c7b8d9c94a59992d0e4e93c448ab66081ef77e3942d3e6015bf9f1
+size 6151

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.rrd
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:812af00963ec345138b360fc0d5712e7ae8a0702f30b977a31d9f187c0bf3e9f
+size 12354480

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eb6d077e7c57fb383752dadf296d61db842570d629b3296788a09079713beca
+size 31148280

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07482b7161a659d45413151689e3609698ece419feb6ba4debbad6bab82fa398
+size 684

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3d8ea2ca03a5e8adae16e1968b2fca652cde391eb5fc5c68780949d6944afbf
+size 6133

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.rrd
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54f6d2437f80ada20b3c6f78fd7bce767337fbfc66e15dcecb232947002afbb0
+size 12354477

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a61dc450a4585f90bdc244cead76946bb7dd04225303cb8d7074aa6e4d8472c
+size 31148280

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img.aux.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5137ffcc4c745795a1bff6e7b9397d06598db4c5817255e97b8bfa17900e7f91
+size 685

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7ef56c6439c8637f798f6570f80b68a93c76f4e166c4fcc72d1f0a046963df1
+size 6136

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.rrd
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:269417e55ee64186767293d40d51925f22ffe944d43fac0cd787a9bc4c457e5e
+size 12354474

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:493c5d7b40336bc6596db0771540b84f17d770bae1dafc67f1a8425673f07362
+size 31148280

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcfb2275a142db991d96fb728ddea3368bc3c0d6dcc7cc0cba0a8f98e5a9c8a6
+size 684

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img.xml
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8113d55a182dd9f5d8cd7cd3d835a60be6dbda859e08d9222984b2ccde0c0be
+size 6143

--- a/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.rrd
+++ b/results/wy2016/dates/2016_211/ITRC_Delta_2016_Jul_29_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfc0f242569f1b5b94f7f7b95b5df8cc4f0edbda373af19772935caa0bbeb8b6
+size 12354475

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f7792eecd855317488c807092efaa857850ffa07d6202154ab726741152edae
+size 31148299

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4e63709d81b219cd1435befaa1704696026664d1744b1fe1ad7d0e17e0bb26c
+size 1668

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42717b5400b288fc7a2b51f02e2c342226efab47f4359bef9db38e8c5951a99e
+size 6151

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.rrd
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7e6146f8f2f80a6e9aaa95deefe96abe7bd73eccf73c2a4e888c76108b2cbac
+size 12354480

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:544e5bd10390e850f6ff467adcbf9f2d07a010981a82b4864ab6429553acdf39
+size 31148280

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f74c4173510a653c0b27011a6b1f2d11cb3c2bcea48b8f0d364b8d4aaac88b76
+size 684

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07c325e8f84839ced7f4b01d30f4f0b8bc9a2c83153fd41a465cc095c191b4c0
+size 6133

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.rrd
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba40ae63d86784ff6e205ec3a7117e9cf4b48b2586cd97b3ed44a02d7166fffc
+size 12354477

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce32e04b218b6f8639fb60c3acd334435e2798615da77cf3ea40b24aeffab50e
+size 31148280

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img.aux.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c4aa750ae895c600cf914ad861c1d5325be09efc8eecfacb796b4869fb5bb9e
+size 685

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96e294e63e1fcafe17054a474980008487c4c99ba1b14b06c44ccd72efaa17dc
+size 6136

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.rrd
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d19a54b812fec9790c3d76abe122a56076aa1fc520971e84e5e149abfbfd868
+size 12354474

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29441e3e4799d004ab79d501fe0ede0a472a4a716a5dbeec514ca99012200cec
+size 31148270

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3e7a958a3368ff12902fe9210ed1e5adb742320d2737b44fca73434f56fb0e8
+size 683

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img.xml
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:073b56522c67d8635c46a218909c2a3ebd125a08fe94a3031386d3e6f535fb13
+size 6143

--- a/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.rrd
+++ b/results/wy2016/dates/2016_227/ITRC_Delta_2016_Aug_14_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e9abe5a5ada252c477891e6854072ff0cfed2c51b2ddb043c962e13b8fb02ae
+size 12354475

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a204236f5cc313280c7a535404db20922d50afac35e25c6aaa8a696bfa6d992
+size 31148299

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13ef67cb83f381fbbcc82276e61d6bc81b737c17ae611577d1b465fc925d6144
+size 1648

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90aad5ef1baf25cd67b11bf23f858997f498aef5eeac4b23b057da478799a011
+size 6151

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.rrd
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efb3bcfb0e5b2fae808f87a10b6453a7416f31326b390803cb4e0aee1e675d66
+size 12354480

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5411dc979f1ff6e5861a01384984133971649c82e8647c0286276e3aad2d7646
+size 31148275

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7bc977fb9b0ee3dd0ebda23c307297d632acc336c7a5a08f3ac3518747b9e29
+size 684

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cc1c9b663e508011b3c3b5410064443d79fb5df884f91cde2536bf0e16936a3
+size 6133

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.rrd
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d878310110a1fdb773fa8303e152ce1da8dd432bb3917ea43c2e463801e7c84b
+size 12354477

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6f36148022c6e31fcae1a30915a505edf8608facc79c34e6899690a987e853e
+size 31148280

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img.aux.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cbe86bf9007dfd74b7fc97a543bd582169116f5a8e2344c022b18454f6d8318
+size 685

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d34c4f97bd5b1baa33b8feb065eab21e0323ca8fe4d25aea25731aaa401ff019
+size 6136

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.rrd
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e92ccea24e22fe20f9c72f91d285edb36d06787164ef14fb80ab45d4edc9d796
+size 12354474

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb66ace14630420e1b666e191c7fe09e4916e371ab04e2322382537aa3e11d5
+size 31148280

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32726e3bf4e361e7d605c06dec29534f119631cb7d9656b6e3614b96662f202f
+size 684

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img.xml
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd10a1ee96455ac21d393b0a33f36299068e291761738c1ecf4af1ca97d29b5d
+size 6143

--- a/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.rrd
+++ b/results/wy2016/dates/2016_243/ITRC_Delta_2016_Aug_30_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cebb592c50d6ef8ebda70fceda8a8427f5967a6f34179868eb791c44d4f5da80
+size 12354475

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fce821c89ba325bcc8c6cbbaadc011b90787729ad0658c5763c3d8de358d557f
+size 31148299

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img.aux.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0de67669b2a9b89fa2c446946bd70ba69d9dd1d58ce6bc8d32bdf18bf559210c
+size 1651

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af65af03e3a0838907d82413d9474d3770d57f87557549feabc4577e74069856
+size 6155

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.rrd
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_ET_inst.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44bf37a5ed92132d6ed4fac9f55e6751bdd8b0b54301c27f71089ebe78153d68
+size 12354481

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8aab27b1cedacc1abc4212157beb0a53f91b43534f7b815317521b372962a1da
+size 31148280

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img.aux.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f7c45b64950228a5f42b9ddb93a8b4edf9b2b85b6867a4a1ae448b0a3b8a87
+size 684

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8cd98971b54eced3a28f81a9ecc24876078caf031d6e282329a018133240ad7
+size 6137

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.rrd
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Gadj.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ff24ca50f3e138a171f72c51374f2ca8b040b09c531d2c5751e2d0ac8db66ec
+size 12354478

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:641c0c49ebf8a01fd3c8aad0a8285445c2ed07287b62602415aa22cb94a1a7a5
+size 31148280

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img.aux.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73832661ad7ae73fc5758a1913e4b3737ff1f08c225d437781eb993b5dd2e649
+size 685

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc85aea3472d48a16920be7304965f0f45f56c20987ae0d47349e314ae6cff14
+size 6140

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.rrd
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_H.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a4ecda2dace39ea0eeb7ebae5222b3dcd68f92a5b7f20302420035ff428a716
+size 12354475

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0040c24e43a0042aea4f1b80ea9bed5213476ec72ac9b6eb5b2f26aab580f57
+size 31148275

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img.aux.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd54181b5cbf8657fdd0b6d4864040ebc8b9d9c520f3946e768dc2046263c2e7
+size 684

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img.xml
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.img.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c79e30d1ff5399fb83b94917a5212a5bcc78f53c1b0a6721347c3cdf069063a7
+size 6147

--- a/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.rrd
+++ b/results/wy2016/dates/2016_259/ITRC_Delta_2016_Sept_15_Rn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ff7da079d37f38404ee7181440c85927d197453f008f7301f728e73e28b6889
+size 12354476

--- a/results/wy2016/dates/README.md
+++ b/results/wy2016/dates/README.md
@@ -7,4 +7,3 @@ Following the lead of some of the landsat products, we suggest that you organize
 ## CSV Files.
 
 You can summarize your individual dates into csv files similar to those described in the above results directory.
-

--- a/results/wy2016/monthly/ITRC_Delta_WY2016_Kc_co.tif
+++ b/results/wy2016/monthly/ITRC_Delta_WY2016_Kc_co.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93324b0b9664585fde949ba8ce08c82efea2d450543b7ecf78bd8fbf8656a222
+size 314508487

--- a/results/wy2016/monthly/ITRC_Delta_WY2016_Kc_or.tif
+++ b/results/wy2016/monthly/ITRC_Delta_WY2016_Kc_or.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c93a573fc73ec71b8cb1503aa53f166fd89a8bbbc9201d60921350e3706fe7
+size 314250214

--- a/results/wy2016/monthly/ITRC_Delta_WY2016_dailyAvg_ET_co.tif
+++ b/results/wy2016/monthly/ITRC_Delta_WY2016_dailyAvg_ET_co.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8113f8da688464ad8db2b52c8f18989b05d7c23e4d9763cf58a842470ef21736
+size 317651452

--- a/results/wy2016/monthly/ITRC_Delta_WY2016_dailyAvg_ET_or.tif
+++ b/results/wy2016/monthly/ITRC_Delta_WY2016_dailyAvg_ET_or.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98f1f102e6959d8dee4bb17fb1fafc2837aefe795cc285072c7c63d1b6a0342a
+size 344871256

--- a/results/wy2016/monthly/README.md
+++ b/results/wy2016/monthly/README.md
@@ -1,0 +1,13 @@
+# Monthly Water Year 2016
+
+This directory should hold rasters for the monthly datasets
+
+# Rasters
+
+You must supply ```ET.tif``` showing the average daily _ET_ for the Delta Service area for the entire year.  This should have 12 bands, and the first band should correspond to the first month of the water year, 2015-10.
+
+Supplying any of the additional parameters, _Kc_, _H_, _G_, would be very helpful.  Again supply these as 12 band files.
+
+# CSV files
+
+Any CSV files should be stored in the above directory.


### PR DESCRIPTION
@djhowes Please review this request to merge the rasters from the box upload into the master branch. 

 - All raster files are stored with git lfs
 - geotiffs were compressed using `DEFLATE` in gdal
 - Files were organized into the water year folders in the results folder
 - ET inst, Rn, G adj, H files were placed in the dates subfolder for the appropriate water year. Folders were named following the convention in the readme of wateryr_julianday (ie 2015_144)

Additional things to do:
 - Update the readme files 
 - What is the final output for the ET monthly raster for this model ? CO or OR ?  
 - Mark with a release tag and upload final output to EarthEngine @andybell